### PR TITLE
Remove trailing slash on vKontakte profile URLs

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -308,7 +308,7 @@ class IRC(threading.Thread):
                     settings.logger.log("SNSCRAPE - Running with updated settings - snscrape " + quote(module) + " " + newtarget.strip() + " >jobs/vkontakte-" + jobid)
                     subprocess.run("snscrape " + quote(module) + " " + newtarget.strip() + " >jobs/vkontakte-" + jobid, shell=True)
                     settings.logger.log('SNSCRAPE - Finished ' + jobid + ' - Uploading to https://transfer.notkiska.pw/' + module + "-" + sanityregex.sub(r'',target))
-                    profileline = "https://vk.com/" + newtarget.strip() + "/"
+                    profileline = "https://vk.com/" + newtarget.strip()
                     lines = [profileline + "\n"]
                     with open("jobs/vkontakte-" + jobid, "r") as outfile:
                         for line in outfile.read().split():
@@ -324,7 +324,7 @@ class IRC(threading.Thread):
                 else:
                     self.send('PRIVMSG', '!ao < {uploadedurl} --explain "For {user} - socialscrape job {jobid}" ' \
                           .format(user=user, uploadedurl=uploadedurl, jobid=jobid), channel)
-                    self.send('PRIVMSG', 'chromebot: a https://vk.com/{target}/'.format(target=newtarget), channel)
+                    self.send('PRIVMSG', 'chromebot: a https://vk.com/{target}'.format(target=newtarget), channel)
 
     def command(self, command, user, channel):
         if command[0] == 'help':


### PR DESCRIPTION
https://vk.com/navalny/ redirects to https://vk.com/navalny now, which causes ArchiveBot not to grab the latter due to `--no-parent`. That redirect was added sometime in the past half year or so.